### PR TITLE
configure authcallback to protect backend api

### DIFF
--- a/frontend/src/AppRoutes.tsx
+++ b/frontend/src/AppRoutes.tsx
@@ -1,6 +1,7 @@
 import { Navigate, Route, Routes } from 'react-router';
 import Layout from './layouts/Layout';
 import Homepage from './pages/Homepage';
+import AuthCallbackPage from './pages/AuthCallbackPage';
 
 const AppRoutes = () => {
     return (
@@ -13,6 +14,7 @@ const AppRoutes = () => {
                     </Layout>
                 }
             />
+            <Route path="/auth-callback" element={<AuthCallbackPage />} />
             <Route path="/user-profile" element={<h1>user profile page</h1>} />
             <Route path="*" element={<Navigate to="/" />} />
         </Routes>

--- a/frontend/src/api/MyUserApi.tsx
+++ b/frontend/src/api/MyUserApi.tsx
@@ -1,3 +1,4 @@
+import { useAuth0 } from '@auth0/auth0-react';
 import { useMutation } from '@tanstack/react-query';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
@@ -8,10 +9,14 @@ type CreateUserRequest = {
 };
 
 export const useCreateMyUser = () => {
+    const { getAccessTokenSilently } = useAuth0();
+
     const createMyUserRequest = async (user: CreateUserRequest) => {
+        const auth0AccessToken = await getAccessTokenSilently();
         const response = await fetch(`${API_BASE_URL}/api/my/user`, {
             method: 'POST',
             headers: {
+                Authorization: `Bearer ${auth0AccessToken}`,
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify(user),

--- a/frontend/src/auth/Auth0ProviderWithNavigate.tsx
+++ b/frontend/src/auth/Auth0ProviderWithNavigate.tsx
@@ -1,12 +1,13 @@
-import { useCreateMyUser } from '@/api/MyUserApi';
-import { Auth0Provider, User, type AppState } from '@auth0/auth0-react';
+import { Auth0Provider } from '@auth0/auth0-react';
+import { useNavigate } from 'react-router';
 
 type Props = {
     children: React.ReactNode;
 };
 
 const Auth0ProviderWithNavigate = ({ children }: Props) => {
-    const { createUser } = useCreateMyUser();
+    const navigate = useNavigate();
+
     const domain = import.meta.env.VITE_AUTH0_DOMAIN;
     const clientId = import.meta.env.VITE_AUTH0_CLIENT_ID;
     const redirectURI = import.meta.env.VITE_AUTH0_CALLBACK_URL;
@@ -17,10 +18,8 @@ const Auth0ProviderWithNavigate = ({ children }: Props) => {
         );
     }
 
-    const onRedirectCallback = (appState?: AppState, user?: User) => {
-        if (user?.sub && user?.email) {
-            createUser({ auth0Id: user.sub, email: user.email });
-        }
+    const onRedirectCallback = () => {
+        navigate('/auth-callback');
     };
 
     return (

--- a/frontend/src/pages/AuthCallbackPage.tsx
+++ b/frontend/src/pages/AuthCallbackPage.tsx
@@ -1,0 +1,33 @@
+import { useCreateMyUser } from '@/api/MyUserApi';
+import { useAuth0 } from '@auth0/auth0-react';
+import { Loader } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router';
+
+const AuthCallbackPage = () => {
+    const navigate = useNavigate();
+    const { user } = useAuth0();
+    const { createUser } = useCreateMyUser();
+
+    const hasCreatedUser = useRef(false);
+
+    useEffect(() => {
+        // create user in mongodb if the auth0 redirected user is not already present
+        // hold calling createUser api on every re-render with useRef
+        // navigate to homepage after the user is created in mongodb
+        if (user?.sub && user?.email && !hasCreatedUser.current) {
+            createUser({ auth0Id: user.sub, email: user.email });
+            hasCreatedUser.current = true;
+        }
+        navigate('/');
+    }, [createUser, navigate, user]);
+
+    return (
+        <div className="text-center text-orange-400 flex gap-2 items-center">
+            <Loader className="spin-in" />
+            Signing you in...
+        </div>
+    );
+};
+
+export default AuthCallbackPage;


### PR DESCRIPTION
added auth callback component to protect the backend apis.

when redirected from auth0, we want to save the user to mongodb. this should only happen by the actual user client side. Means, session must be valid to know that the request to save the user to db is from an actual user. This will be done using the access token provided by auth0